### PR TITLE
fix TOS & deleteBucket modal (on error)

### DIFF
--- a/src/views/Buckets/Bucket-Files/index.vue
+++ b/src/views/Buckets/Bucket-Files/index.vue
@@ -109,7 +109,7 @@ export default {
         })
         .catch((err) => {
           this.submitting = false;
-          this.$root.$emit('hide::modal', 'deleteBucketModal');
+          this.$root.$emit('bv::hide::modal', 'deleteBucketModal');
           this.error = err;
         });
     }

--- a/src/views/Signup/index.vue
+++ b/src/views/Signup/index.vue
@@ -30,7 +30,7 @@
                   v-model="initialPassword"
                 />
               </div>
-              
+
               <div v-if="error" class="form-group">
                 <input
                   type="password"
@@ -230,11 +230,11 @@ export default {
     },
 
     openEula () {
-      this.$root.$emit('show::modal', 'eulaModal');
+      this.$root.$emit('bv::show::modal', 'eulaModal');
     },
 
     closeEula () {
-      this.$root.$emit('hide::modal', 'eulaModal');
+      this.$root.$emit('bv::hide::modal', 'eulaModal');
     }
   }
 };


### PR DESCRIPTION
Looks like a typo in the use of bootstrap-vue modals. It seems that the "delete bucket" modal's error condition for the `deleteBucket` api request was also typo'd.

#### [Relevant bootstrap-vue docs](https://bootstrap-vue.js.org/docs/components/modal/#emitting-events-on-root)
#### [Related trello card](https://trello.com/c/fKKspHhS/33-there-is-a-problem-with-the-signup-page-https-appstorjio-signup-if-you-click-on-the-terms-of-service-link-in-i-agree-to-the-term)